### PR TITLE
build.gradle記述

### DIFF
--- a/bid-generator/build.gradle
+++ b/bid-generator/build.gradle
@@ -1,0 +1,14 @@
+group 'snp-ssp'
+version '0.0.1-SNAPSHOT'
+
+apply plugin: 'java'
+
+sourceCompatibility = 1.8
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testCompile group: 'junit', name: 'junit', version: '4.11'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,12 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenLocal()
         mavenCentral()
         maven { url "http://repo.spring.io/milestone" }
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.3.3.RELEASE")
+        classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.2.5.RELEASE'
+        classpath 'io.spring.gradle:dependency-management-plugin:0.5.2.RELEASE'
     }
 }
 
@@ -22,7 +23,62 @@ repositories {
 }
 
 group 'snp-ssp'
-version '0.0.1-SNAPSHOT'
+
+
+configure(applicationProjects()) {
+    apply plugin: 'java'
+    apply plugin: 'eclipse'
+    apply plugin: 'idea'
+    apply plugin: 'io.spring.dependency-management'
+
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+
+    [compileJava, compileTestJava]*.options.each {
+        it.encoding = 'UTF-8'
+        it.compilerArgs = ['-Xlint:all,-serial,-processing']
+    }
+
+    sourceSets {
+        main.compileClasspath += configurations.provided
+        test.compileClasspath += configurations.provided
+        test.runtimeClasspath += configurations.provided
+    }
+
+    idea.module.scopes.PROVIDED.plus += [configurations.provided]
+
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        jcenter()
+    }
+
+    configurations {
+        provided
+    }
+
+    idea.module.scopes.PROVIDED.plus += [configurations.provided]
+
+    dependencies {
+        compile 'joda-time:joda-time:2.9.2',
+                'org.scala-lang:scala-library:2.11.7'
+        testCompile('junit:junit:4.+') {
+            exclude group: 'org.hamcrest'
+        }
+        testCompile('org.mockito:mockito-core:1.+') {
+            exclude group: 'org.hamcrest'
+        }
+        testCompile 'org.assertj:assertj-core:3.1.0'
+    }
+
+    bootRun {
+        systemProperty "user.timezone", "UTC"
+
+        if (project.hasProperty('args')) {
+            args project.args.split('\\s+')
+        }
+    }
+}
 
 dependencies {
     compile 'joda-time:joda-time:2.9.2',
@@ -43,6 +99,13 @@ dependencies {
 jar {
     baseName = 'snp-ssp'
     version = version
+}
+
+def applicationProjects() {
+    subprojects -
+            project('ssp-web') -
+            project('ssp-web-admin') -
+            project('bid-generator')
 }
 
 task wrapper(type: Wrapper) {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         maven { url "http://repo.spring.io/milestone" }
     }
     dependencies {
-        classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.2.5.RELEASE'
+        classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.3.3.RELEASE'
         classpath 'io.spring.gradle:dependency-management-plugin:0.5.2.RELEASE'
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,5 @@
 rootProject.name = 'snp-ssp'
 
+include 'bid-generator'
+include 'ssp-web'
+include 'ssp-web-admin'

--- a/ssp-web-admin/build.gradle
+++ b/ssp-web-admin/build.gradle
@@ -1,0 +1,14 @@
+group 'snp-ssp'
+version '0.0.1-SNAPSHOT'
+
+apply plugin: 'java'
+
+sourceCompatibility = 1.8
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testCompile group: 'junit', name: 'junit', version: '4.11'
+}

--- a/ssp-web/build.gradle
+++ b/ssp-web/build.gradle
@@ -1,0 +1,14 @@
+group 'snp-ssp'
+version '0.0.1-SNAPSHOT'
+
+apply plugin: 'java'
+
+sourceCompatibility = 1.8
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testCompile group: 'junit', name: 'junit', version: '4.11'
+}


### PR DESCRIPTION
- rootのSNPモジュールに、`ssp-web`, `ssp-web-admin`, `bid-generator`の3つのサブモジュールがぶら下がっている構成に修正
- 全プロジェクトに共通の記述は、root直下のbuild.gradleに記述
